### PR TITLE
Remove speech marks around links

### DIFF
--- a/vignettes/acute-kidney-injury-10x-visium-rasterized.Rmd
+++ b/vignettes/acute-kidney-injury-10x-visium-rasterized.Rmd
@@ -216,7 +216,7 @@ pos_aligned_plot
 
 # Create SpatialExperiment 
 
-Now that we have created counts matrices and aligned positions matrices we need to create a [`SpatialExperiment`]("https://www.bioconductor.org/packages/release/bioc/html/SpatialExperiment.html") as this is the required input form for the functions we want to use in `STcompare` (and `SEraster`). A `SpatialExperiment` is an object that store spatial transcriptomics data, in this case, combining gene expression matrices as `assays` with the spatial coordinates of each spatial location as `spatialCoords`. 
+Now that we have created counts matrices and aligned positions matrices we need to create a [`SpatialExperiment`](https://www.bioconductor.org/packages/release/bioc/html/SpatialExperiment.html) as this is the required input form for the functions we want to use in `STcompare` (and `SEraster`). A `SpatialExperiment` is an object that store spatial transcriptomics data, in this case, combining gene expression matrices as `assays` with the spatial coordinates of each spatial location as `spatialCoords`.
 
 ``` {r create_spatial_experiment1}
 AKI_ctrl_SE <- SpatialExperiment::SpatialExperiment(

--- a/vignettes/getting-started-with-STcompare.Rmd
+++ b/vignettes/getting-started-with-STcompare.Rmd
@@ -68,7 +68,7 @@ library(reshape2)
 
 Here we load the simulated kidney data `speKidney` that we will use to demonstrate `spatialCorrelation` and `spatialSimilarity`
 
-`speKidney` is a list of three `SpatialExperiment` objects representing three simulated single-cell kidney datasets named A, B, and C. A [`SpatialExperiment`]("https://www.bioconductor.org/packages/release/bioc/html/SpatialExperiment.html")  object store spatial transcriptomics data, combining gene expression matrices with the spatial coordinates of each spatial location. Each element of `speKidney` contains `assays`: gene-by-cell expression matrices and `spatialCoords`: x–y spatial coordinates for each spatial location.
+`speKidney` is a list of three `SpatialExperiment` objects representing three simulated single-cell kidney datasets named A, B, and C. A [`SpatialExperiment`](https://www.bioconductor.org/packages/release/bioc/html/SpatialExperiment.html)  object store spatial transcriptomics data, combining gene expression matrices with the spatial coordinates of each spatial location. Each element of `speKidney` contains `assays`: gene-by-cell expression matrices and `spatialCoords`: x–y spatial coordinates for each spatial location.
 
 
 ```{r load_data}
@@ -173,10 +173,10 @@ Comparing the mean between A and B does not capture the spatial gene expression 
 
 1. **Tissue Alignment**\
   For `STcompare` to produce meaningful comparisons, the tissues must first be spatially aligned so that corresponding structures are matched across samples.
-  The `STalign` package can be used to align two tissues. [STalign Tutorial]("https://jef.works/STalign/notebooks/merfish-merfish-alignment.html")
+  The `STalign` package can be used to align two tissues. [STalign Tutorial](https://jef.works/STalign/notebooks/merfish-merfish-alignment.html)
 
 2. **Rasterization**\
-  `STcompare` takes a list of [`SpatialExperiment`]("https://bioconductor.org/packages/release/bioc/html/SpatialExperiment.html") objects and requires them to have matched spatial locations. Use `SEraster` to rasterize multiple samples onto the same coordinate system, allowing `STcompare` to pairwise compare across any number of samples. [SEraster formatting tutorial]("https://jef.works/SEraster/articles/formatting-SpatialExperiment-for-SEraster.html")
+  `STcompare` takes a list of [`SpatialExperiment`](https://bioconductor.org/packages/release/bioc/html/SpatialExperiment.html) objects and requires them to have matched spatial locations. Use `SEraster` to rasterize multiple samples onto the same coordinate system, allowing `STcompare` to pairwise compare across any number of samples. [SEraster formatting tutorial](https://jef.works/SEraster/articles/formatting-SpatialExperiment-for-SEraster.html)
 
 
 Since our simulated data is already aligned we first use `SEraster` to rasterize this list of simulated kidneys, stored as `SpatialExperiment` objects, onto the same coordinate plane. 


### PR DESCRIPTION
These were causing links to malfunction in the vignettes. I haven't tested whether this fixes the issue, but I think it should.

P.S. Thanks for the nice tool - cool approach :)